### PR TITLE
adding podman kubic repo for ubuntu 22.04

### DIFF
--- a/nephio-ansible-install/roles/podman/tasks/main.yaml
+++ b/nephio-ansible-install/roles/podman/tasks/main.yaml
@@ -3,6 +3,30 @@
 ## SPDX-License-Identifier: Apache-2.0
 
 ---
+- name: setup apt repo
+  block:
+    - name: kubic podman repo key add
+      ansible.builtin.get_url:
+        url: "https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_{{ ansible_distribution_version }}/Release.key"
+        dest: /etc/apt/trusted.gpg.d/kubic.key
+
+    - name: kubic podman repo apt source
+      ansible.builtin.apt_repository:
+        repo: "deb [signed-by=/etc/apt/trusted.gpg.d/kubic.key] https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_{{ ansible_distribution_version }}/ /"
+        state: present
+    - name: Unmask and enable podman.socket
+      ansible.builtin.systemd:
+        name: podman.socket
+        enabled: true
+        masked: no
+    - name: Unmask, Enable and start podman.service
+      ansible.builtin.systemd:
+        name: podman.service
+        enabled: true
+        masked: no
+  when: ansible_distribution == 'Ubuntu'
+
+
 - name: installing podman
   become: true
   ansible.builtin.package:

--- a/nephio-ansible-install/roles/podman/tasks/main.yaml
+++ b/nephio-ansible-install/roles/podman/tasks/main.yaml
@@ -14,6 +14,16 @@
       ansible.builtin.apt_repository:
         repo: "deb [signed-by=/etc/apt/trusted.gpg.d/kubic.key] https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_{{ ansible_distribution_version }}/ /"
         state: present
+  when: ansible_distribution == 'Ubuntu'
+
+- name: installing podman
+  become: true
+  ansible.builtin.package:
+    name: "podman"
+    state: latest
+
+- name: enable podman systemd units on Ubuntu
+  block:
     - name: Unmask and enable podman.socket
       ansible.builtin.systemd:
         name: podman.socket
@@ -25,13 +35,6 @@
         enabled: true
         masked: no
   when: ansible_distribution == 'Ubuntu'
-
-
-- name: installing podman
-  become: true
-  ansible.builtin.package:
-    name: "podman"
-    state: latest
 
 - name: create podman network for kind
   containers.podman.podman_network:


### PR DESCRIPTION
This is to get Ubuntu 22.04 to work with podman.

The repo is referenced on the podman page but does only carry releases for 22.04 jammy ... so overall this is not fully optimal but a starting point.